### PR TITLE
Adding target_os windows for windows syscalls

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,12 +17,13 @@ pub fn get_iana_time_zone() -> Result<DynamicTimeZone, DynamicTimeZoneError> {
     DynamicTimeZone::get()
 }
 
+#[cfg(target_os = "windows")]
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn it_works() {
+    fn windows_test_runner() {
         let DynamicTimeZone::DaylightSavingsTimeZone(tz) = get_iana_time_zone().unwrap() else { panic!() };
         println!("{:?}", tz.tz_key_name.as_str());
         println!("{:?}", tz.tz_key_name);


### PR DESCRIPTION
Want to make sure that the code paths with windows system calls are configured for `target_os = "windows"`