### PR TITLE
Add support for fetching the geoname from windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ version = "0.59.0"
 features = [
     "Win32_System_Time",
     "Win32_Foundation",
+    "Win32_Globalization"
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ pub enum DynamicTimeZoneError {
     IllformedTimeZoneString,
     FileReadError,
     DeserializeDataError,
+    ParsingError(tinystr::ParseError),
+    SyscallErrorCode(u32),
 }
 
 #[cfg(target_os = "windows")]
@@ -27,14 +29,17 @@ pub fn get_win_time_zone() -> Result<DynamicTimeZone, DynamicTimeZoneError> {
 
 #[cfg(target_os = "windows")]
 pub fn get_iana_time_zone() -> Result<String, DynamicTimeZoneError> {
+    use windows::get_geoname;
+
     let local = DynamicTimeZone::get()?;
+    let geoname = get_geoname()?;
 
     match local {
         DynamicTimeZone::DaylightSavingsTimeZone(zoneinfo) => {
-            map_win_tz_to_iana_tz(zoneinfo.tz_key_name.as_str(), None)
+            map_win_tz_to_iana_tz(zoneinfo.tz_key_name.as_str(), Some(geoname.as_str()))
         }
         DynamicTimeZone::StandardTimeZone(zoneinfo) => {
-            map_win_tz_to_iana_tz(zoneinfo.tz_key_name.as_str(), None)
+            map_win_tz_to_iana_tz(zoneinfo.tz_key_name.as_str(), Some(geoname.as_str()))
         }
     }
 }


### PR DESCRIPTION
So it's definitely wasn't `RegionCode` although there may still be something there yet.

RegionCode appears to just be directly from `ICU`, but it's not entirely clear how to construct a `URegion` from the `isize` provided. It may be fetchable via `uregion_getRegionFromCode`. But that function has a `PCSTR` parameter while `GetUserDefaultGeoName` is a `LPWSTR`. I'm not exactly sure the best way to convert betweent the two currently ... so I'll leave that be.